### PR TITLE
refactor-003 Fixed issue of search API giving 500 error because of in…

### DIFF
--- a/src/main/java/org/webshar/hrms/enums/EmployeeSortBy.java
+++ b/src/main/java/org/webshar/hrms/enums/EmployeeSortBy.java
@@ -1,7 +1,7 @@
 package org.webshar.hrms.enums;
 
 public enum EmployeeSortBy {
-  EMPLOYEE_ID,
-  EMPLOYEE_FIRST_NAME,
+  EMP_ID,
+  FIRST_NAME,
   JOINING_DATE
 }

--- a/src/main/java/org/webshar/hrms/model/db/Employee.java
+++ b/src/main/java/org/webshar/hrms/model/db/Employee.java
@@ -22,36 +22,47 @@ import lombok.ToString;
 @JsonInclude(Include.NON_NULL)
 public class Employee extends BaseModel {
 
-  /**
-   *
-   */
   private static final long serialVersionUID = 1L;
+
   @Column(name = "emp_id", nullable = false, unique = true, length = 11)
   private String empId;
+
   @Column(name = "organization_id", nullable = false, unique = true, length = 11)
   private Long organizationId;
+
   @Column(name = "first_name", nullable = false, length = 100)
   private String firstName;
+
   @Column(name = "middle_name", length = 100)
   private String middleName;
+
   @Column(name = "last_name", nullable = false, length = 100)
   private String lastName;
+
   @Column(name = "date_of_birth", nullable = false)
   private Date dateOfBirth;
+
   @Column(name = "is_active", nullable = false)
   private Boolean isActive;
+
   @Column(name = "email", nullable = false, length = 100)
   private String email;
+
   @Column(name = "joining_date", nullable = false, updatable = false)
   private Date joiningDate;
+
   @Column(name = "exit_date")
   private Date exitDate;
+
   @Column(name = "address", length = 300)
   private String address;
+
   @Column(name = "contact", nullable = false, length = 100)
   private String contact;
+
   @Column(name = "designation", nullable = false, length = 200)
   private String designation;
+
   @OneToOne(cascade = CascadeType.ALL)
   @JoinColumn(name = "reports_to", referencedColumnName = "id")
   private Employee reportsTo;

--- a/src/main/java/org/webshar/hrms/repository/impl/EmployeeRepositoryImpl.java
+++ b/src/main/java/org/webshar/hrms/repository/impl/EmployeeRepositoryImpl.java
@@ -24,12 +24,12 @@ public class EmployeeRepositoryImpl implements EmployeeRepositoryCustom {
   EntityManager entityManager;
 
   public static String getSortByValue(final EmployeeSearchRequest employeeSearchRequest) {
-    String sortBy = "employeeId";
+    String sortBy = "empId";
     switch (EmployeeSortBy.valueOf(employeeSearchRequest.getSortBy())) {
-      case EMPLOYEE_ID:
-        sortBy = "employeeId";
+      case EMP_ID:
+        sortBy = "empId";
         break;
-      case EMPLOYEE_FIRST_NAME:
+      case FIRST_NAME:
         sortBy = "firstName";
         break;
       case JOINING_DATE:

--- a/src/main/java/org/webshar/hrms/request/employee/EmployeeSearchRequest.java
+++ b/src/main/java/org/webshar/hrms/request/employee/EmployeeSearchRequest.java
@@ -22,7 +22,7 @@ public class EmployeeSearchRequest {
   private Integer perPage;
   @ApiModelProperty(value = "page", example = "1")
   private Integer page;
-  @ApiModelProperty(value = "sortBy", example = "EMPLOYEE_ID")
+  @ApiModelProperty(value = "sortBy", example = "EMP_ID")
   private String sortBy;
   @ApiModelProperty(value = "order", example = "ASC")
   private String order;
@@ -36,25 +36,21 @@ public class EmployeeSearchRequest {
       setOrder("DESC");
     }
 
-    for (Order o : Order.values()) {
-      if (o.name().equals(order)) {
-        return true;
-      }
-    }
-    return false;
+    return Arrays.stream(Order.values())
+        .map(Order::name)
+        .anyMatch(o -> o.equals(order));
   }
 
   @AssertTrue(message = ErrorMessageConstants.EMPLOYEE_INVALID_INVALID_SORT_BY_COLUMN)
   public boolean isValidSortBy() {
     if (StringUtils.isEmpty(sortBy)) {
-      setSortBy("EMPLOYEE_ID");
+      this.setSortBy("EMP_ID");
     }
-    for (EmployeeSortBy sortParam : EmployeeSortBy.values()) {
-      if (sortParam.name().equals(sortBy)) {
-        return true;
-      }
-    }
-    return false;
+
+    return Arrays.stream(EmployeeSortBy.values())
+        .map(EmployeeSortBy::name)
+        .anyMatch(s -> s.equals(sortBy));
+
   }
 
   @AssertTrue(message = ErrorMessageConstants.INVALID_PER_PAGE_VALUE)


### PR DESCRIPTION
Recently `employeeId` is renamed to `empId`. It seems that the impact of this change was not fixed in search `employee` flow. Thus API was giving the 500 error. Fixed this under this PR.